### PR TITLE
Add Test Notebooks for Emollama-7b with Task-Specific Prompts

### DIFF
--- a/test_notebooks/Emollama-7b.ipynb
+++ b/test_notebooks/Emollama-7b.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModelForCausalLM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Emollama-7b**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d9776c0ef204330ad6bd80d2ffe2d78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\"lzw1008/Emollama-7b\")\n",
+    "model = AutoModelForCausalLM.from_pretrained(\"lzw1008/Emollama-7b\", device_map='auto')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Emotion intensity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human: \n",
+      "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.\n",
+      "Text: @CScheiwiller can't stop smiling 😆😆😆\n",
+      "Emotion: joy\n",
+      "Intensity Score:\n",
+      "\n",
+      "Assistant:\n",
+      " 0.854\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human: \n",
+    "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.\n",
+    "Text: @CScheiwiller can't stop smiling 😆😆😆\n",
+    "Emotion: joy\n",
+    "Intensity Score:\n",
+    "\n",
+    "Assistant:\n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.  \n",
+      "Text: Ugh, that really pissed me off! 😡  \n",
+      "Emotion: anger  \n",
+      "Intensity Score:  \n",
+      "\n",
+      "Assistant:  \n",
+      " 0.708\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.  \n",
+    "Text: Ugh, that really pissed me off! 😡  \n",
+    "Emotion: anger  \n",
+    "Intensity Score:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.  \n",
+      "Text: Wow! That’s incredible! 😮  \n",
+      "Emotion: surprise  \n",
+      "Intensity Score:  \n",
+      "\n",
+      "Assistant: 0.667\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Assign a numerical value between 0 (least E) and 1 (most E) to represent the intensity of emotion E expressed in the text.  \n",
+    "Text: Wow! That’s incredible! 😮  \n",
+    "Emotion: surprise  \n",
+    "Intensity Score:  \n",
+    "\n",
+    "Assistant: '''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sentiment strength"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:\n",
+      "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).\n",
+      "Text: Happy Birthday shorty. Stay fine stay breezy stay wavy @daviistuart 😘\n",
+      "Intensity Score:\n",
+      "\n",
+      "Assistant:\n",
+      " 0.783\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:\n",
+    "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).\n",
+    "Text: Happy Birthday shorty. Stay fine stay breezy stay wavy @daviistuart 😘\n",
+    "Intensity Score:\n",
+    "\n",
+    "Assistant:\n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).  \n",
+      "Text: I’m really disappointed in how things turned out.  \n",
+      "Intensity Score:  \n",
+      "\n",
+      "Assistant:  \n",
+      " 0.229\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).  \n",
+    "Text: I’m really disappointed in how things turned out.  \n",
+    "Intensity Score:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).  \n",
+      "Text: This is the best news I’ve heard all year! I’m so excited!  \n",
+      "Intensity Score:  \n",
+      "\n",
+      "Assistant:  \n",
+      " 0.854\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Evaluate the valence intensity of the writer's mental state based on the text, assigning it a real-valued score from 0 (most negative) to 1 (most positive).  \n",
+    "Text: This is the best news I’ve heard all year! I’m so excited!  \n",
+    "Intensity Score:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sentiment classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:\n",
+      "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred\n",
+      "Text: Beyoncé resentment gets me in my feelings every time. 😩\n",
+      "Intensity Class:\n",
+      "\n",
+      "Assistant:\n",
+      " -2: moderately negative emotional state can be inferred\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:\n",
+    "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred\n",
+    "Text: Beyoncé resentment gets me in my feelings every time. 😩\n",
+    "Intensity Class:\n",
+    "\n",
+    "Assistant:\n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred.  \n",
+      "Text: Honestly, I feel like nothing is going right lately.  \n",
+      "Intensity Class:  \n",
+      "\n",
+      "Assistant:  \n",
+      " -2: moderately negative emotional state can be inferred\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred.  \n",
+    "Text: Honestly, I feel like nothing is going right lately.  \n",
+    "Intensity Class:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred.  \n",
+      "Text: I can’t believe I finally got the promotion! This is amazing!  \n",
+      "Intensity Class:  \n",
+      "\n",
+      "Assistant:  \n",
+      " 2: moderately positive emotional state can be inferred\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Categorize the text into an ordinal class that best characterizes the writer's mental state, considering various degrees of positive and negative sentiment intensity. 3: very positive mental state can be inferred. 2: moderately positive mental state can be inferred. 1: slightly positive mental state can be inferred. 0: neutral or mixed mental state can be inferred. -1: slightly negative mental state can be inferred. -2: moderately negative mental state can be inferred. -3: very negative mental state can be inferred.  \n",
+    "Text: I can’t believe I finally got the promotion! This is amazing!  \n",
+    "Intensity Class:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Emotion classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:\n",
+      "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).\n",
+      "Text: Whatever you decide to do make sure it makes you #happy.\n",
+      "This text contains emotions:\n",
+      "\n",
+      "Assistant: joy, optimism.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:\n",
+    "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).\n",
+    "Text: Whatever you decide to do make sure it makes you #happy.\n",
+    "This text contains emotions:\n",
+    "\n",
+    "Assistant:'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).  \n",
+      "Text: I’m really nervous about the results, but I’m trying to stay hopeful.  \n",
+      "This text contains emotions:  \n",
+      "\n",
+      "Assistant:  \n",
+      " fear, optimism, sadness.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).  \n",
+    "Text: I’m really nervous about the results, but I’m trying to stay hopeful.  \n",
+    "This text contains emotions:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human:  \n",
+      "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).  \n",
+      "Text: Nothing much to say, just another regular day.  \n",
+      "This text contains emotions:  \n",
+      "\n",
+      "Assistant:  \n",
+      " neutral or no emotion.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = '''Human:  \n",
+    "Task: Categorize the text's emotional tone as either 'neutral or no emotion' or identify the presence of one or more of the given emotions (anger, anticipation, disgust, fear, joy, love, optimism, pessimism, sadness, surprise, trust).  \n",
+    "Text: Nothing much to say, just another regular day.  \n",
+    "This text contains emotions:  \n",
+    "\n",
+    "Assistant:  \n",
+    "'''\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "# Generate\n",
+    "generate_ids = model.generate(inputs[\"input_ids\"], max_length=256)\n",
+    "response = tokenizer.batch_decode(generate_ids, skip_special_tokens=True)[0]\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "BaseEnv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I've added a new directory named test_notebooks which contains a test notebook for Emollama-7b. The notebook includes several test prompts for evaluating various tasks such as emotion intensity, sentiment strength, sentiment classification, and emotion classification.